### PR TITLE
Fix failing unit tests in test_files.py

### DIFF
--- a/tests/unit/events/observation/test_files.py
+++ b/tests/unit/events/observation/test_files.py
@@ -19,23 +19,23 @@ class TestFileObservations(unittest.TestCase):
 
     def test_file_read_observation(self):
         """Test the FileReadObservation class."""
-        obs = FileReadObservation(path='/test/file.txt')
+        obs = FileReadObservation(path='/test/file.txt', content='Test content')
         self.assertEqual('I read the file /test/file.txt.', obs.message)
         self.assertTrue(
-            str(obs).startswith('[Read from /test/file.txt is successful.\n')
+            str(obs) == '[Read from /test/file.txt is successful.]\nTest content'
         )
 
     def test_file_write_observation(self):
         """Test the FileWriteObservation class."""
-        obs = FileWriteObservation(path='/test/file.txt')
+        obs = FileWriteObservation(path='/test/file.txt', content='Test content')
         self.assertEqual('I wrote to the file /test/file.txt.', obs.message)
         self.assertTrue(
-            str(obs).startswith('[Write to /test/file.txt is successful.\n')
+            str(obs) == '[Write to /test/file.txt is successful.]\nTest content'
         )
 
     def test_file_edit_observation(self):
         """Test the FileEditObservation class."""
-        obs = FileEditObservation(path='/test/file.py')
+        obs = FileEditObservation(path='/test/file.py', content='Test content')
         # Test basic properties
         self.assertEqual('I edited the file /test/file.py.', obs.message)
 


### PR DESCRIPTION

This PR fixes the failing unit tests in `test_files.py` by adding the required `content` parameter to the test cases.

The issue was that the base `Observation` class requires a `content` parameter, but the test cases were not providing it.
